### PR TITLE
Reimplemented GENESIS .p to swc converter to be more robust

### DIFF
--- a/convert_to_swc.py
+++ b/convert_to_swc.py
@@ -13,19 +13,17 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.'''
 
-#Usage:  
-#Output: filenameconvert.p
+# Usage:
+# Output: filenameconvert.p
 
-#George Mason University
-#Jonathan Reed and Zhi Cheng Wu
-#March 1, 2019
+# George Mason University
+# Jonathan Reed and Zhi Cheng Wu
+# March 1, 2019
+# Rewritten by Subhasis Ray, 2025-04-17
 
 import argparse
 import datetime
 from convert_swc_pfile import read_data_comments
-PARENT=1
-SELF=0
-DIAM=5
 
 if __name__ == '__main__':
 
@@ -36,44 +34,85 @@ if __name__ == '__main__':
 
     lines = open(filename, 'r').readlines()
 
-    data_lines,comment_lines=read_data_comments(lines)
-    
-    comment_lines.append('# Original .p file : '+filename + '\n')
-    comment_lines.append('# Modified to .swc file on : '+str(datetime.datetime.now()) + '\n')
+    data_lines, comment_lines = read_data_comments(lines)
+
+    comment_lines.append('# Original .p file : ' + filename + '\n')
+    comment_lines.append(
+        '# Modified to .swc file on : ' + str(datetime.datetime.now()) + '\n'
+    )
 
     all_new_lines = []
-    #rearranges values for .p format
-    for num, line in enumerate(data_lines):
-        newline = [line[x] for x in range(6)]
-        newline[5] = round(float(line[5])/2,4) #replace diameter with radius
-        #very first line has no parent, and is of type soma
-        if num == 0:
-            newline.append(-1) #parent
-            newline[PARENT] = 1  #type
-        #splicing underscore out and choosing portion of the value desired
+    # rearranges values for .p format
+    # Columns in the .p format are
+    #     compartment_name parent_name x y z diameter
+    # whereas swc format has
+    #    node_id structure_type x y z radius parent_id
+    #
+    proto_fields = ('comp', 'parent', 'x', 'y', 'z', 'dia')
+    swc_fields = ('comp', 'stype', 'x', 'y', 'z', 'rad', 'parent')
+    proto_list = [dict(zip(proto_fields, line)) for line in data_lines]
+    swc_list = []
+    swc_dict = {}
+    root = None
+    for pdict in proto_list:
+        name, stype = pdict['comp'].split('_')
+        sdict = {
+            'comp': name,
+            'stype': stype,
+            'rad': float(pdict['dia']) / 2.0,
+            'children': [],
+        }
+        swc_dict[name] = sdict
+        swc_list.append(sdict)
+        if pdict['parent'] == 'none':
+            sdict['parent'] = '-1'
         else:
-            newline.append( newline[PARENT].split('_')[0]) #parent
-            newline[PARENT] = newline[0].split('_')[1] #type
-        newline[SELF] = newline[SELF].split('_')[0] #self
-        #creates list of newline that can be recorded to search for previous neurons
-        all_new_lines.append(newline)
-        parentneuron = int(newline[6])
-        #print(num,'*** relative:', newline,'parent=',parentneuron)
-        if int(parentneuron) > 0:
-            for x in range(2,5):
-                #convert from relative to absolute coordinates, but not for first line
-                #print(newline[x], 'add to', all_new_lines[parentneuron-1][x])
-                newline[x] = round(float(newline[x])+float(all_new_lines[parentneuron-1][x]),4)
-            #print('   abs',newline,'\n','  parent',parentneuron,' :',all_new_lines[parentneuron-1])
+            sdict['parent'] = pdict['parent'].split('_')[0]
+        sdict['x'] = float(pdict['x'])
+        sdict['y'] = float(pdict['y'])
+        sdict['z'] = float(pdict['z'])
+        sdict['children'] = []
+
+    # Now construct the tree to convert the relative x,y,z to absolute
+    for name, sdict in swc_dict.items():
+        parent = sdict['parent']
+        if parent == '-1':
+            root = name
+        else:
+            swc_dict[parent]['children'].append(name)
+
+    assert root is not None, 'Could not find root element'
+
+    stack = [root]
+    visited = set()
+    while stack:
+        node = stack.pop()
+        if node in visited:
+            continue
+        visited.add(node)
+        parent = swc_dict[node]['parent']
+        if parent != '-1':
+            for dim in ('x', 'y', 'z'):
+                swc_dict[node][dim] = round(
+                    swc_dict[node][dim] + swc_dict[parent][dim], 4
+                )
+        stack.extend(swc_dict[node]['children'])
 
     out_name = filename.split('.p')[0] + '.swc'
-    outfile = open(out_name,'w')
+    outfile = open(out_name, 'w')
     for line in comment_lines:
-        outfile.write(line)
-    for line in all_new_lines:
-        write_line = ' '.join([str(val) for val in line]) #converts from list of strings to single string
+        outfile.write(f'# {line}')
+    for sdict in swc_list:
+        write_line = ' '.join(
+            [str(sdict[key]) for key in swc_fields]
+        )  # converts from list of strings to single string
         outfile.write(write_line + '\n')
     outfile.close()
 
-    print('Converted ' + str(len(data_lines)) + ' compartments from original file : ' + str(filename))
+    print(
+        'Converted '
+        + str(len(data_lines))
+        + ' compartments from original file : '
+        + str(filename)
+    )
     print('Modified file created : ' + str(out_name))


### PR DESCRIPTION
Earlier implementation assumed all compartment ids in the .p file to be sequential numbers. So the conversion failed even for some .p files generated by `convert_pfile_swc.py` where this assumption was violated.

This updated implementation traverses the compartment tree without such assumption, and is more robust.

Also, comments and globals were directly copied to SWC, now the
 conventional comment character `#` is inserted before such
 lines.